### PR TITLE
Atualizando configuração do linter gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,3 +25,7 @@ linters:
     - typecheck
     - unconvert
     - unused
+linters-settings:
+  gocritic:
+    disabled-checks:
+      - commentFormatting


### PR DESCRIPTION
- Desabilitando check _commentFormatting_